### PR TITLE
Raise default find time from 30 to 60 seconds

### DIFF
--- a/src/test/java/com/checkmarx/intellij/ui/BaseUITest.java
+++ b/src/test/java/com/checkmarx/intellij/ui/BaseUITest.java
@@ -102,7 +102,7 @@ public abstract class BaseUITest {
 
     protected static <T extends ComponentFixture> T find(Class<T> cls,
                                                          @Language("XPath") String xpath) {
-        return find(cls, xpath, Duration.ofSeconds(30));
+        return find(cls, xpath, Duration.ofSeconds(60));
     }
 
     protected static <T extends ComponentFixture> T find(Class<T> cls,


### PR DESCRIPTION
### Description

Raise default time to find a component from 30 to 60 seconds.

### References

N/A

### Testing

N/A

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used