### PR TITLE
support version 2021.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,12 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = '2021.2'
+    version = '2021.1'
     updateSinceUntilBuild = false
 }
 
 runPluginVerifier {
-    ideVersions = ['IC-2021.2', 'IC-2021.3']
+    ideVersions = ['IC-2021.1', 'IC-2021.2', 'IC-2021.3']
 }
 
 downloadRobotServerPlugin {
@@ -67,5 +67,5 @@ java {
 }
 
 patchPluginXml {
-    sinceBuild = '212'
+    sinceBuild = '211'
 }


### PR DESCRIPTION
### Description

Support intellij framework version 2021.1 as Android Studio lags behind in versioning.

### References

N/A

### Testing

N/A

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used