### PR TITLE
Fix state menu visual bug on android studio

### DIFF
--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/filter/Filterable.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/filter/Filterable.java
@@ -1,14 +1,12 @@
 package com.checkmarx.intellij.tool.window.actions.filter;
 
-import com.intellij.util.ui.EmptyIcon;
-
 import javax.swing.*;
 import java.util.function.Supplier;
 
 public interface Filterable {
 
     default Icon getIcon() {
-        return EmptyIcon.ICON_0;
+        return null;
     }
 
     Supplier<String> tooltipSupplier();

--- a/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
@@ -389,7 +389,7 @@ public class ResultNode extends DefaultMutableTreeNode {
             if(i == bfl) {
                 label.setIcon(CxIcons.CHECKMARX_13_COLOR);
             } else {
-                label.setIcon(EmptyIcon.ICON_8);
+                label.setIcon(EmptyIcon.ICON_13);
             }
 
             CxLinkLabel link = new CxLinkLabel(capToLen(node.getFileName()),


### PR DESCRIPTION
Use null icon instead of EMPTY_0 to properly display the state action menu in 2021.1

### Description

Icon EMPTY_0 caused a visual bug on the state filter menu in 2021.1 / Android Studio. Changed it to null icon.

### References

N/A

### Testing

Manual testing as it is a visual bug

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used