### PR TITLE
AST-37667 upgrade the wrapper version and send the agent to the results command function

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'com.miglayout:miglayout-swing:11.2'
 
     if (javaWrapperVersion == "" || javaWrapperVersion == null) {
-        implementation 'com.checkmarx.ast:ast-cli-java-wrapper:1.0.64'
+        implementation 'com.checkmarx.ast:ast-cli-java-wrapper:2.0.11'
     } else {
         implementation 'com.checkmarx.ast:ast-cli-java-wrapper:' + javaWrapperVersion
     }

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'com.miglayout:miglayout-swing:11.3'
 
     if (javaWrapperVersion == "" || javaWrapperVersion == null) {
-        implementation('com.checkmarx.ast:ast-cli-java-wrapper:2.0.11'){
+        implementation('com.checkmarx.ast:ast-cli-java-wrapper:2.0.12'){
             exclude group: 'junit', module: 'junit'
         }
     } else {

--- a/src/main/java/com/checkmarx/intellij/Constants.java
+++ b/src/main/java/com/checkmarx/intellij/Constants.java
@@ -77,4 +77,5 @@ public final class Constants {
 
     public static final String SCAN_STATUS_RUNNING = "running";
     public static final String SCAN_STATUS_COMPLETED = "completed";
+    public static final String JET_BRAINS_AGENT_NAME = "jetBrains";
 }

--- a/src/main/java/com/checkmarx/intellij/Constants.java
+++ b/src/main/java/com/checkmarx/intellij/Constants.java
@@ -77,5 +77,5 @@ public final class Constants {
 
     public static final String SCAN_STATUS_RUNNING = "running";
     public static final String SCAN_STATUS_COMPLETED = "completed";
-    public static final String JET_BRAINS_AGENT_NAME = "jetBrains";
+    public static final String JET_BRAINS_AGENT_NAME = "JetBrains";
 }

--- a/src/main/java/com/checkmarx/intellij/Constants.java
+++ b/src/main/java/com/checkmarx/intellij/Constants.java
@@ -77,5 +77,5 @@ public final class Constants {
 
     public static final String SCAN_STATUS_RUNNING = "running";
     public static final String SCAN_STATUS_COMPLETED = "completed";
-    public static final String JET_BRAINS_AGENT_NAME = "JetBrains";
+    public static final String JET_BRAINS_AGENT_NAME = "Jetbrains";
 }

--- a/src/main/java/com/checkmarx/intellij/commands/Scan.java
+++ b/src/main/java/com/checkmarx/intellij/commands/Scan.java
@@ -2,6 +2,7 @@ package com.checkmarx.intellij.commands;
 
 import com.checkmarx.ast.wrapper.CxConfig;
 import com.checkmarx.ast.wrapper.CxException;
+import com.checkmarx.intellij.Constants;
 import com.checkmarx.intellij.settings.global.CxWrapperFactory;
 import org.jetbrains.annotations.NotNull;
 
@@ -82,7 +83,7 @@ public class Scan {
         scanArguments.put("-s", sourcePath);
         scanArguments.put("--project-name", projectName);
         scanArguments.put("--branch", branchName);
-        scanArguments.put("--agent", "Jetbrains");
+        scanArguments.put("--agent", Constants.JET_BRAINS_AGENT_NAME);
 
         String additionalParameters = "--async --sast-incremental --resubmit";
 

--- a/src/main/java/com/checkmarx/intellij/commands/results/Results.java
+++ b/src/main/java/com/checkmarx/intellij/commands/results/Results.java
@@ -3,6 +3,7 @@ package com.checkmarx.intellij.commands.results;
 import com.checkmarx.ast.wrapper.CxConfig;
 import com.checkmarx.ast.wrapper.CxException;
 import com.checkmarx.intellij.Bundle;
+import com.checkmarx.intellij.Constants;
 import com.checkmarx.intellij.Resource;
 import com.checkmarx.intellij.Utils;
 import com.checkmarx.intellij.commands.Scan;
@@ -63,7 +64,7 @@ public class Results {
 
             com.checkmarx.ast.results.Results results;
             try {
-                results = CxWrapperFactory.build().results(UUID.fromString(scanId));
+                results = CxWrapperFactory.build().results(UUID.fromString(scanId), Constants.JET_BRAINS_AGENT_NAME);
             } catch (IOException | URISyntaxException | CxException | CxConfig.InvalidCLIConfigException | InterruptedException e) {
                 newState.setMessage(Bundle.message(Resource.GETTING_RESULTS_ERROR,
                                                    scanId + Utils.formatLatest(getLatest)));


### PR DESCRIPTION


By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Upgrade the wrapper version
> Send the agent name (JetBrains) to the results command. the agent used to filter the containers results when the plugin didn't add the support of the new engine (containers)

### References

> https://checkmarx.atlassian.net/browse/AST-37667

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used