### PR TITLE
JetBrains | Fix Deprecated getActionUpdateThread function (AST-65497)

### DIFF
--- a/src/main/java/com/checkmarx/intellij/settings/global/GlobalSettingsComponent.java
+++ b/src/main/java/com/checkmarx/intellij/settings/global/GlobalSettingsComponent.java
@@ -35,9 +35,8 @@ import java.util.concurrent.CompletableFuture;
 public class GlobalSettingsComponent implements SettingsComponent {
     private static final Logger LOGGER = Utils.getLogger(GlobalSettingsComponent.class);
 
-    private final static GlobalSettingsState SETTINGS_STATE = GlobalSettingsState.getInstance();
-    private final static GlobalSettingsSensitiveState SENSITIVE_SETTINGS_STATE
-            = GlobalSettingsSensitiveState.getInstance();
+    private static GlobalSettingsState SETTINGS_STATE;
+    private static GlobalSettingsSensitiveState SENSITIVE_SETTINGS_STATE;
 
     private final MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
 
@@ -52,6 +51,12 @@ public class GlobalSettingsComponent implements SettingsComponent {
     private final JBLabel validateResult = new JBLabel();
 
     public GlobalSettingsComponent() {
+        if (SETTINGS_STATE == null) {
+            SETTINGS_STATE = GlobalSettingsState.getInstance();
+        }
+        if (SENSITIVE_SETTINGS_STATE == null) {
+            SENSITIVE_SETTINGS_STATE = GlobalSettingsSensitiveState.getInstance();
+        }
         addValidateConnectionListener();
 
         setupFields();

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/CancelScanAction.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/CancelScanAction.java
@@ -8,6 +8,7 @@ import com.checkmarx.intellij.commands.Scan;
 import com.intellij.ide.ActivityTracker;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.notification.NotificationType;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
@@ -62,8 +63,12 @@ public class CancelScanAction extends AnAction implements CxToolWindowAction {
             e.getPresentation().setEnabled(isScanRunning);
         }
         catch (Exception ex) {
-            ex.printStackTrace();
-            e.getPresentation().setEnabled(false);
+            e.getPresentation().setEnabled(true);
         }
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/CollapseAllAction.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/CollapseAllAction.java
@@ -3,6 +3,7 @@ package com.checkmarx.intellij.tool.window.actions;
 import com.checkmarx.intellij.Bundle;
 import com.checkmarx.intellij.Resource;
 import com.checkmarx.intellij.tool.window.CxToolWindowPanel;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import org.jetbrains.annotations.NotNull;
@@ -27,5 +28,10 @@ public class CollapseAllAction extends AnAction implements CxToolWindowAction {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Optional.ofNullable(getCxToolWindowPanel(e)).ifPresent(CxToolWindowPanel::collapseAll);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
     }
 }

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/ExpandAllAction.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/ExpandAllAction.java
@@ -3,6 +3,7 @@ package com.checkmarx.intellij.tool.window.actions;
 import com.checkmarx.intellij.Bundle;
 import com.checkmarx.intellij.Resource;
 import com.checkmarx.intellij.tool.window.CxToolWindowPanel;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import org.jetbrains.annotations.NotNull;
@@ -27,5 +28,10 @@ public class ExpandAllAction extends AnAction implements CxToolWindowAction {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Optional.ofNullable(getCxToolWindowPanel(e)).ifPresent(CxToolWindowPanel::expandAll);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
     }
 }

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/OpenSettingsAction.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/OpenSettingsAction.java
@@ -3,6 +3,7 @@ package com.checkmarx.intellij.tool.window.actions;
 import com.checkmarx.intellij.Bundle;
 import com.checkmarx.intellij.Resource;
 import com.checkmarx.intellij.settings.global.GlobalSettingsConfigurable;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.options.ShowSettingsUtil;
@@ -26,5 +27,10 @@ public class OpenSettingsAction extends AnAction implements CxToolWindowAction {
     public void actionPerformed(@NotNull AnActionEvent e) {
         ShowSettingsUtil.getInstance()
                         .showSettingsDialog(e.getProject(), GlobalSettingsConfigurable.class);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
     }
 }

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/StartScanAction.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/StartScanAction.java
@@ -15,6 +15,7 @@ import com.intellij.dvcs.repo.Repository;
 import com.intellij.ide.ActivityTracker;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.notification.*;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
@@ -71,7 +72,6 @@ public class StartScanAction extends AnAction implements CxToolWindowAction {
                 userHasPermissionsToScan = TenantSetting.isScanAllowed();
             } catch (Exception ex) {
                 userHasPermissionsToScan = false;
-                LOGGER.error(ex);
             }
         }
         return userHasPermissionsToScan;
@@ -289,7 +289,6 @@ public class StartScanAction extends AnAction implements CxToolWindowAction {
             e.getPresentation().setEnabled(!isScanRunning && !isPollingScan && !scanTriggered && projectAndBranchSelected);
         }
         catch (Exception ex) {
-            LOGGER.error(ex);
             e.getPresentation().setEnabled(false);
         }
     }
@@ -310,5 +309,10 @@ public class StartScanAction extends AnAction implements CxToolWindowAction {
      */
     private static String msg(Resource resource, Object... params) {
         return Bundle.message(resource, params);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/filter/FilterBaseAction.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/filter/FilterBaseAction.java
@@ -4,6 +4,7 @@ import com.checkmarx.intellij.settings.global.GlobalSettingsState;
 import com.checkmarx.intellij.tool.window.ResultState;
 import com.checkmarx.intellij.tool.window.Severity;
 import com.checkmarx.intellij.tool.window.actions.CxToolWindowAction;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.ToggleAction;
 import com.intellij.openapi.application.ApplicationManager;
@@ -210,5 +211,10 @@ public abstract class FilterBaseAction extends ToggleAction implements CxToolWin
          * Method called when a filter is clicked.
          */
         void filterChanged();
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
     }
 }

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/group/by/GroupByActionGroup.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/group/by/GroupByActionGroup.java
@@ -1,5 +1,6 @@
 package com.checkmarx.intellij.tool.window.actions.group.by;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.project.DumbAware;
@@ -11,5 +12,10 @@ public class GroupByActionGroup extends DefaultActionGroup implements DumbAware 
     public void update(@NotNull AnActionEvent e) {
         super.update(e);
         e.getPresentation().setEnabled(true);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
     }
 }

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/group/by/GroupByBaseAction.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/group/by/GroupByBaseAction.java
@@ -2,6 +2,7 @@ package com.checkmarx.intellij.tool.window.actions.group.by;
 
 import com.checkmarx.intellij.tool.window.actions.CxToolWindowAction;
 import com.checkmarx.intellij.tool.window.GroupBy;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.ToggleAction;
 import com.intellij.openapi.util.NlsActions;
@@ -32,4 +33,9 @@ public abstract class GroupByBaseAction extends ToggleAction implements CxToolWi
     }
 
     protected abstract GroupBy getGroupBy();
+
+    @Override
+    public ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
+    }
 }

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/selection/BaseSelectionGroup.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/selection/BaseSelectionGroup.java
@@ -6,6 +6,7 @@ import com.checkmarx.intellij.Resource;
 import com.checkmarx.intellij.tool.window.actions.CxToolWindowAction;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.project.DumbAware;
@@ -83,4 +84,10 @@ public abstract class BaseSelectionGroup extends DefaultActionGroup implements D
      * @param scan overriding scan
      */
     abstract void override(Scan scan);
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
+    }
+
 }

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/selection/BranchSelectionGroup.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/selection/BranchSelectionGroup.java
@@ -5,6 +5,7 @@ import com.checkmarx.intellij.Bundle;
 import com.checkmarx.intellij.Constants;
 import com.checkmarx.intellij.Resource;
 import com.checkmarx.intellij.Utils;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/selection/ResetSelectionAction.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/selection/ResetSelectionAction.java
@@ -4,6 +4,7 @@ import com.checkmarx.intellij.Bundle;
 import com.checkmarx.intellij.Resource;
 import com.checkmarx.intellij.tool.window.actions.CxToolWindowAction;
 import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import lombok.Getter;
@@ -44,5 +45,10 @@ public class ResetSelectionAction extends AnAction implements CxToolWindowAction
             cxToolWindowPanel.refreshPanel();
             cxToolWindowPanel.resetPanel();
         });
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
     }
 }

--- a/src/main/java/com/checkmarx/intellij/tool/window/actions/selection/RootGroup.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/actions/selection/RootGroup.java
@@ -2,6 +2,7 @@ package com.checkmarx.intellij.tool.window.actions.selection;
 
 import com.checkmarx.intellij.commands.Scan;
 import com.checkmarx.intellij.tool.window.actions.CxToolWindowAction;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.DumbAware;
@@ -64,9 +65,12 @@ public class RootGroup extends DefaultActionGroup implements DumbAware, CxToolWi
         projectSelectionGroup.setEnabled(enabled);
         branchSelectionGroup.setEnabled(enabled);
         scanSelectionGroup.setEnabled(enabled);
-        resetSelectionAction.setEnabled(enabled);
+        if (resetSelectionAction != null) {
+            resetSelectionAction.setEnabled(enabled);
+        }
         refreshPanel(project);
     }
+
 
     public void reset() {
         projectSelectionGroup.clear();
@@ -74,5 +78,10 @@ public class RootGroup extends DefaultActionGroup implements DumbAware, CxToolWi
         scanSelectionGroup.clear();
         refreshPanel(project);
         projectSelectionGroup.refresh();
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
     }
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Override deprecated function getActionUpdateThread that uses OLD_EDT and fixing it by overrideng it to use EDT to BGT depends on the case

### References

> https://checkmarx.atlassian.net/browse/AST-65497

### Testing

> X

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used