### PR TITLE
Fix tag pattern to correctly delete specified tag

### DIFF
--- a/.github/workflows/delete-dev-releases.yml
+++ b/.github/workflows/delete-dev-releases.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Delete releases and tags
         continue-on-error: true
-        uses: dev-drprasad/delete-older-releases@v0.2.1
+        uses: dev-drprasad/delete-older-releases@653dc03d96473ac9e585c68c8bf5aaccb0dadb61 #v0.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/delete-dev-releases.yml
+++ b/.github/workflows/delete-dev-releases.yml
@@ -22,7 +22,6 @@ jobs:
   delete:
     runs-on: ubuntu-latest
     steps:
-
       - name: Delete releases and tags
         continue-on-error: true
         uses: dev-drprasad/delete-older-releases@v0.2.1
@@ -30,5 +29,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           keep_latest: 0
-          delete_tag_pattern: "-${{inputs.tag}}"
+          delete_tag_pattern: "${{ inputs.tag }}"
           delete_tags: true


### PR DESCRIPTION
This commit updates the delete_tag_pattern in the GitHub Actions workflow used for deleting releases and tags.
The previous pattern incorrectly included an extra dash (-) before the tag input,
 which caused the action to fail to find and delete tags
