### PR TITLE
Add test for organization mismatch should be project doesn't match (AST-79785)

### DIFF
--- a/src/main/java/com/checkmarx/intellij/Constants.java
+++ b/src/main/java/com/checkmarx/intellij/Constants.java
@@ -58,6 +58,8 @@ public final class Constants {
     public static final String SELECTED_SCAN_PROPERTY = "Checkmarx.SelectedScan";
     public static final String RUNNING_SCAN_ID_PROPERTY = "Checkmarx.RunningScanId";
 
+    public static final String NOT_MATCH_PROJECT_NAME_DIFF_ORGANIZATION = "Phoenix/WebGoat";
+
     public static final String SCAN_TYPE_SCA = "sca";
     public static final String SCAN_TYPE_KICS = "kics";
 

--- a/src/main/java/com/checkmarx/intellij/Constants.java
+++ b/src/main/java/com/checkmarx/intellij/Constants.java
@@ -58,8 +58,6 @@ public final class Constants {
     public static final String SELECTED_SCAN_PROPERTY = "Checkmarx.SelectedScan";
     public static final String RUNNING_SCAN_ID_PROPERTY = "Checkmarx.RunningScanId";
 
-    public static final String NOT_MATCH_PROJECT_NAME_DIFF_ORGANIZATION = "Phoenix/WebGoat";
-
     public static final String SCAN_TYPE_SCA = "sca";
     public static final String SCAN_TYPE_KICS = "kics";
 

--- a/src/test/java/com/checkmarx/intellij/ui/TestTriggerScan.java
+++ b/src/test/java/com/checkmarx/intellij/ui/TestTriggerScan.java
@@ -71,11 +71,9 @@ public class TestTriggerScan extends BaseUITest {
     @Test
     @Video
     public void testTriggerScanProjectWithDifferentOrganizationsDontMatch() {
-
-        if (triggerScanNotAllowed()) return;
         waitFor(() -> findSelection("Scan").isEnabled() && findSelection("Project").isEnabled() && findSelection("Branch").isEnabled() && findSelection("Scan").isEnabled());
-        testSelectionAction(findSelection("Project"), "Project", Constants.NOT_MATCH_PROJECT_NAME_DIFF_ORGANIZATION);
-        testSelectionAction(findSelection("Branch"), "Branch", Environment.BRANCH_NAME);
+        testSelectionAction(findSelection("Project"), "Project", "DiffOrg/WebGoat");
+        testSelectionAction(findSelection("Branch"), "Branch", Environment.NOT_MATCH_BRANCH_NAME);
         testSelectionAction(findSelection("Scan"), "Scan", Environment.SCAN_ID_NOT_MATCH_PROJECT);
         waitFor(() -> findSelection("Scan").isEnabled() && findSelection("Project").isEnabled() && findSelection("Branch").isEnabled());
         findRunScanButtonAndClick();

--- a/src/test/java/com/checkmarx/intellij/ui/TestTriggerScan.java
+++ b/src/test/java/com/checkmarx/intellij/ui/TestTriggerScan.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-
+import com.checkmarx.intellij.Constants;
 import static com.checkmarx.intellij.ui.utils.RemoteRobotUtils.*;
 import static com.checkmarx.intellij.ui.utils.Xpath.*;
 
@@ -67,6 +67,21 @@ public class TestTriggerScan extends BaseUITest {
         findRunScanButtonAndClick();
         Assertions.assertTrue(hasAnyComponent(BRANCH_DOES_NOT_MATCH));
     }
+
+    @Test
+    @Video
+    public void testTriggerScanProjectWithDifferentOrganizationsDontMatch() {
+
+        if (triggerScanNotAllowed()) return;
+        waitFor(() -> findSelection("Scan").isEnabled() && findSelection("Project").isEnabled() && findSelection("Branch").isEnabled() && findSelection("Scan").isEnabled());
+        testSelectionAction(findSelection("Project"), "Project", Constants.NOT_MATCH_PROJECT_NAME_DIFF_ORGANIZATION);
+        testSelectionAction(findSelection("Branch"), "Branch", Environment.BRANCH_NAME);
+        testSelectionAction(findSelection("Scan"), "Scan", Environment.SCAN_ID_NOT_MATCH_PROJECT);
+        waitFor(() -> findSelection("Scan").isEnabled() && findSelection("Project").isEnabled() && findSelection("Branch").isEnabled());
+        findRunScanButtonAndClick();
+        Assertions.assertTrue(hasAnyComponent(PROJECT_DOES_NOT_MATCH));
+    }
+
 
     @Test
     @Video

--- a/src/test/java/com/checkmarx/intellij/ui/TestTriggerScan.java
+++ b/src/test/java/com/checkmarx/intellij/ui/TestTriggerScan.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import com.checkmarx.intellij.Constants;
 import static com.checkmarx.intellij.ui.utils.RemoteRobotUtils.*;
 import static com.checkmarx.intellij.ui.utils.Xpath.*;
 

--- a/src/test/java/com/checkmarx/intellij/ui/TestTriggerScan.java
+++ b/src/test/java/com/checkmarx/intellij/ui/TestTriggerScan.java
@@ -72,7 +72,7 @@ public class TestTriggerScan extends BaseUITest {
     public void testTriggerScanProjectWithDifferentOrganizationsDontMatch() {
         waitFor(() -> findSelection("Scan").isEnabled() && findSelection("Project").isEnabled() && findSelection("Branch").isEnabled() && findSelection("Scan").isEnabled());
         testSelectionAction(findSelection("Project"), "Project", "DiffOrg/WebGoat");
-        testSelectionAction(findSelection("Branch"), "Branch", Environment.NOT_MATCH_BRANCH_NAME);
+        testSelectionAction(findSelection("Branch"), "Branch", Environment.BRANCH_NAME);
         testSelectionAction(findSelection("Scan"), "Scan", Environment.SCAN_ID_NOT_MATCH_PROJECT);
         waitFor(() -> findSelection("Scan").isEnabled() && findSelection("Project").isEnabled() && findSelection("Branch").isEnabled());
         findRunScanButtonAndClick();


### PR DESCRIPTION


### Description

> dding a warning for the user when the SCM project doesn't match the CX project - TESTS

### References

>https://checkmarx.atlassian.net/browse/AST-79785

### Testing

> add ui test

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used