### PR TITLE
Added CWE link to Learn More section in IDE (AST-94778)

### DIFF
--- a/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
@@ -4,10 +4,7 @@ import com.checkmarx.ast.codebashing.CodeBashing;
 import com.checkmarx.ast.learnMore.LearnMore;
 import com.checkmarx.ast.learnMore.Sample;
 import com.checkmarx.ast.predicate.Predicate;
-import com.checkmarx.ast.results.result.DependencyPath;
-import com.checkmarx.ast.results.result.Node;
-import com.checkmarx.ast.results.result.PackageData;
-import com.checkmarx.ast.results.result.Result;
+import com.checkmarx.ast.results.result.*;
 import com.checkmarx.ast.scan.Scan;
 import com.checkmarx.ast.wrapper.CxConstants;
 import com.checkmarx.ast.wrapper.CxException;
@@ -1052,9 +1049,9 @@ public class ResultNode extends DefaultMutableTreeNode {
         JBLabel cweLinkTitle = new JBLabel(String.format(Constants.HTML_BOLD_FORMAT, boldLabel("CWE Link").getText()));
         panel.add(cweLinkTitle, "span, growx");
 
-        String linkdetails = "https://cwe.mitre.org/data/definitions/" + result.getVulnerabilityDetails().getCweId() + ".html";
-
-        if (StringUtils.isNotBlank(linkdetails)) {
+        VulnerabilityDetails vulnerabilityDetails = result.getVulnerabilityDetails();
+        if (vulnerabilityDetails != null && StringUtils.isNotBlank(vulnerabilityDetails.getCweId())) {
+            String linkdetails = "https://cwe.mitre.org/data/definitions/" + vulnerabilityDetails.getCweId() + ".html";
             JBLabel cweLinkLabel = new JBLabel(String.format(Constants.HTML_WRAPPER_FORMAT, linkdetails.replaceAll("\n", "<br/>")));
             cweLinkLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
             cweLinkLabel.addMouseListener(new MouseAdapter() {
@@ -1068,6 +1065,8 @@ public class ResultNode extends DefaultMutableTreeNode {
                 }
             });
             panel.add(cweLinkLabel, "wrap, gapbottom 3, gapleft 0");
+        } else {
+
         }
     }
 

--- a/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
@@ -1048,6 +1048,27 @@ public class ResultNode extends DefaultMutableTreeNode {
             panel.add(new JBLabel(String.format(Constants.HTML_WRAPPER_FORMAT, recommendations.replaceAll("\n", "<br/>"))),
                     "wrap, gapbottom 3, gapleft 0");
         }
+
+        JBLabel cweLinkTitle = new JBLabel(String.format(Constants.HTML_BOLD_FORMAT, boldLabel("CWE Link").getText()));
+        panel.add(cweLinkTitle, "span, growx");
+
+        String linkdetails = "https://cwe.mitre.org/data/definitions/" + result.getVulnerabilityDetails().getCweId() + ".html";
+
+        if (StringUtils.isNotBlank(linkdetails)) {
+            JBLabel cweLinkLabel = new JBLabel(String.format(Constants.HTML_WRAPPER_FORMAT, linkdetails.replaceAll("\n", "<br/>")));
+            cweLinkLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+            cweLinkLabel.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    try {
+                        Desktop.getDesktop().browse(new URI(linkdetails));
+                    } catch (IOException | URISyntaxException ex) {
+                        LOGGER.error("Failed to open CWE link", ex);
+                    }
+                }
+            });
+            panel.add(cweLinkLabel, "wrap, gapbottom 3, gapleft 0");
+        }
     }
 
     public void generateCodeSamples(@NotNull LearnMore learnMore, JPanel panel) {

--- a/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
+++ b/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
@@ -125,7 +125,9 @@ class ResultNodeTest {
             // Setup
             when(mockLearnMore.getRisk()).thenReturn(TEST_RISK);
             when(mockLearnMore.getCause()).thenReturn(TEST_CAUSE);
-            when(mockLearnMore.getGeneralRecommendations()).thenReturn("Genral Recommendation 1\nGeneral Recommendation 2");
+            when(mockLearnMore.getGeneralRecommendations()).thenReturn("General Recommendation 1\nGeneral Recommendation 2");
+            when(mockResult.getVulnerabilityDetails()).thenReturn(mockVulnDetails);
+            when(mockVulnDetails.getCweId()).thenReturn("79");
             mockedBundle.when(() -> Bundle.message(Resource.RISK)).thenReturn("Risk");
             mockedBundle.when(() -> Bundle.message(Resource.CAUSE)).thenReturn("Cause");
             mockedBundle.when(() -> Bundle.message(Resource.GENERAL_RECOMMENDATIONS)).thenReturn("Recommendations");
@@ -137,12 +139,15 @@ class ResultNodeTest {
             resultNode.generateLearnMore(mockLearnMore, panel);
 
             // Verify
-            assertEquals(6, panel.getComponentCount()); // Risk title, risk content, cause title, cause content, recommendations title
-            assertTrue(panel.getComponent(0) instanceof JLabel);
-            assertTrue(panel.getComponent(1) instanceof JBLabel);
-            assertTrue(panel.getComponent(2) instanceof JLabel);
-            assertTrue(panel.getComponent(3) instanceof JBLabel);
-            assertTrue(panel.getComponent(4) instanceof JLabel);
+            assertEquals(8, panel.getComponentCount()); // Adjusted to 8
+            assertTrue(panel.getComponent(0) instanceof JLabel); // Risk title
+            assertTrue(panel.getComponent(1) instanceof JBLabel); // Risk content
+            assertTrue(panel.getComponent(2) instanceof JLabel); // Cause title
+            assertTrue(panel.getComponent(3) instanceof JBLabel); // Cause content
+            assertTrue(panel.getComponent(4) instanceof JLabel); // Recommendations title
+            assertTrue(panel.getComponent(5) instanceof JLabel); // CWE Link title
+            assertTrue(panel.getComponent(6) instanceof JBLabel); // CWE Link label
+            assertTrue(panel.getComponent(7) instanceof JBLabel); // Verify the new component
         }
     }
 
@@ -152,6 +157,8 @@ class ResultNodeTest {
             // Setup
             when(mockLearnMore.getRisk()).thenReturn("");
             when(mockLearnMore.getCause()).thenReturn("");
+            when(mockResult.getVulnerabilityDetails()).thenReturn(mockVulnDetails);
+            when(mockVulnDetails.getCweId()).thenReturn("79");
             mockedBundle.when(() -> Bundle.message(Resource.RISK)).thenReturn("Risk");
             mockedBundle.when(() -> Bundle.message(Resource.CAUSE)).thenReturn("Cause");
             mockedBundle.when(() -> Bundle.message(Resource.GENERAL_RECOMMENDATIONS)).thenReturn("Recommendations");
@@ -163,10 +170,14 @@ class ResultNodeTest {
             resultNode.generateLearnMore(mockLearnMore, panel);
 
             // Verify
-            assertEquals(3, panel.getComponentCount()); // Only titles, no content
+            assertEquals(5, panel.getComponentCount()); // Titles and CWE link
             assertTrue(panel.getComponent(0) instanceof JLabel); // Risk title
             assertTrue(panel.getComponent(1) instanceof JLabel); // Cause title
             assertTrue(panel.getComponent(2) instanceof JLabel); // Recommendations title
+            assertTrue(panel.getComponent(3) instanceof JLabel); // CWE Link title
+            assertTrue(panel.getComponent(4) instanceof JBLabel); // CWE Link label
+            JBLabel cweLinkLabel = (JBLabel) panel.getComponent(4);
+            assertEquals("<html>https://cwe.mitre.org/data/definitions/79.html</html>", cweLinkLabel.getText());
         }
     }
 
@@ -188,7 +199,7 @@ class ResultNodeTest {
             resultNode.generateLearnMore(mockLearnMore, panel);
 
             // Verify
-            assertEquals(6, panel.getComponentCount());
+            assertEquals(7, panel.getComponentCount());
             JBLabel riskContent = (JBLabel) panel.getComponent(1);
             JBLabel causeContent = (JBLabel) panel.getComponent(3);
             assertEquals(riskContent.getText(), ("<html>Line 1<br/>Line 2</html>"));
@@ -475,32 +486,5 @@ class ResultNodeTest {
         assertTrue(titleLabel.getText().contains("test-package:1.0.0"));
         assertEquals(Severity.HIGH.getIcon(), titleLabel.getIcon());
     }
-
-    @Test
-    void generateLearnMore_WithCweLink_PrintsCweLinkToConsole() {
-        try (MockedStatic<Bundle> mockedBundle = mockStatic(Bundle.class)) {
-            // Setup
-            when(mockLearnMore.getRisk()).thenReturn(TEST_RISK);
-            when(mockLearnMore.getCause()).thenReturn(TEST_CAUSE);
-            when(mockLearnMore.getGeneralRecommendations()).thenReturn("General Recommendation");
-            when(mockResult.getVulnerabilityDetails()).thenReturn(mockVulnDetails);
-            when(mockVulnDetails.getCweId()).thenReturn(TEST_CWE);
-
-            mockedBundle.when(() -> Bundle.message(Resource.RISK)).thenReturn("Risk");
-            mockedBundle.when(() -> Bundle.message(Resource.CAUSE)).thenReturn("Cause");
-            mockedBundle.when(() -> Bundle.message(Resource.GENERAL_RECOMMENDATIONS)).thenReturn("Recommendations");
-
-            resultNode = new ResultNode(mockResult, mockProject, SCAN_ID);
-            JPanel panel = new JPanel();
-
-            // Execute
-            resultNode.generateLearnMore(mockLearnMore, panel);
-
-            // Verify
-            JBLabel cweLinkLabel = (JBLabel) panel.getComponent(6);
-            System.out.println("CWE Link: " + cweLinkLabel.getText());
-        }
-    }
-
 
 }

--- a/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
+++ b/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
@@ -476,5 +476,31 @@ class ResultNodeTest {
         assertEquals(Severity.HIGH.getIcon(), titleLabel.getIcon());
     }
 
+    @Test
+    void generateLearnMore_WithCweLink_PrintsCweLinkToConsole() {
+        try (MockedStatic<Bundle> mockedBundle = mockStatic(Bundle.class)) {
+            // Setup
+            when(mockLearnMore.getRisk()).thenReturn(TEST_RISK);
+            when(mockLearnMore.getCause()).thenReturn(TEST_CAUSE);
+            when(mockLearnMore.getGeneralRecommendations()).thenReturn("General Recommendation");
+            when(mockResult.getVulnerabilityDetails()).thenReturn(mockVulnDetails);
+            when(mockVulnDetails.getCweId()).thenReturn(TEST_CWE);
+
+            mockedBundle.when(() -> Bundle.message(Resource.RISK)).thenReturn("Risk");
+            mockedBundle.when(() -> Bundle.message(Resource.CAUSE)).thenReturn("Cause");
+            mockedBundle.when(() -> Bundle.message(Resource.GENERAL_RECOMMENDATIONS)).thenReturn("Recommendations");
+
+            resultNode = new ResultNode(mockResult, mockProject, SCAN_ID);
+            JPanel panel = new JPanel();
+
+            // Execute
+            resultNode.generateLearnMore(mockLearnMore, panel);
+
+            // Verify
+            JBLabel cweLinkLabel = (JBLabel) panel.getComponent(6);
+            System.out.println("CWE Link: " + cweLinkLabel.getText());
+        }
+    }
+
 
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> This PR adds the missing CWE link to the Learn More section of vulnerability results in IntelliJ IDE. Previously, developers had to manually search for the CWE reference, slowing down the remediation process. **[AST-94778]**

### References

> Include supporting link to GitHub Issue/PR number

### Testing

This change was tested by setting up a test case in the `ResultNodeTest.java` file. The implementation was built using **runIde** and verified locally within IntelliJ IDE.

#### Unit Test:
>The test case generateLearnMore_WithValidData_CreatesPanel ensures that the generateLearnMore method correctly populates a JPanel with 7 components, verifying their types and content, including risk, cause, recommendations, and CWE link.

#### Test Execution:
- The test was executed successfully, ensuring correct linkage of the CWE information.
- Manual validation was performed by interacting with the IDE to confirm visibility of the CWE link.
- All existing tests completed without errors.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used

[AST-94778]: https://checkmarx.atlassian.net/browse/AST-94778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ