### PR TITLE
Other/CWE id integration(AST-96753)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 
     // https://mvnrepository.com/artifact/com.miglayout/miglayout-swing
     implementation 'com.miglayout:miglayout-swing:11.3'
+    implementation 'org.apache.commons:commons-text:1.10.0'
 
     if (javaWrapperVersion == "" || javaWrapperVersion == null) {
         implementation('com.checkmarx.ast:ast-cli-java-wrapper:2.2.1'){

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ dependencies {
 
     // https://mvnrepository.com/artifact/com.miglayout/miglayout-swing
     implementation 'com.miglayout:miglayout-swing:11.3'
-    implementation 'org.apache.commons:commons-text:1.10.0'
 
     if (javaWrapperVersion == "" || javaWrapperVersion == null) {
         implementation('com.checkmarx.ast:ast-cli-java-wrapper:2.2.1'){

--- a/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
@@ -15,7 +15,7 @@ import com.checkmarx.intellij.service.StateService;
 import com.checkmarx.intellij.settings.global.CxWrapperFactory;
 import com.checkmarx.intellij.tool.window.FileNode;
 import com.checkmarx.intellij.tool.window.Severity;
-import com.checkmarx.intellij.tool.window.actions.filter.DynamicFilterActionGroup;
+import org.apache.commons.text.StringEscapeUtils;
 import com.intellij.icons.AllIcons;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.application.ApplicationManager;
@@ -1046,27 +1046,39 @@ public class ResultNode extends DefaultMutableTreeNode {
                     "wrap, gapbottom 3, gapleft 0");
         }
 
+        //[AST-96753] Add CWE link to the learn more section
         JBLabel cweLinkTitle = new JBLabel(String.format(Constants.HTML_BOLD_FORMAT, boldLabel("CWE Link").getText()));
         panel.add(cweLinkTitle, "span, growx");
 
         VulnerabilityDetails vulnerabilityDetails = result.getVulnerabilityDetails();
         if (vulnerabilityDetails != null && StringUtils.isNotBlank(vulnerabilityDetails.getCweId())) {
-            String linkdetails = "https://cwe.mitre.org/data/definitions/" + vulnerabilityDetails.getCweId() + ".html";
-            JBLabel cweLinkLabel = new JBLabel(String.format(Constants.HTML_WRAPPER_FORMAT, linkdetails.replaceAll("\n", "<br/>")));
+            String cweId = vulnerabilityDetails.getCweId();
+            String linkUrl = "https://cwe.mitre.org/data/definitions/" + cweId + ".html";
+            String linkText = "CWE-" + cweId;
+            JBLabel cweLinkLabel = new JBLabel(linkText);
             cweLinkLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+            cweLinkLabel.setForeground(JBColor.BLUE);
+
             cweLinkLabel.addMouseListener(new MouseAdapter() {
                 @Override
                 public void mouseClicked(MouseEvent e) {
                     try {
-                        Desktop.getDesktop().browse(new URI(linkdetails));
+                        Desktop.getDesktop().browse(new URI(linkUrl));
+                        cweLinkLabel.setForeground(JBColor.GRAY); // Mark as visited
                     } catch (IOException | URISyntaxException ex) {
                         LOGGER.error("Failed to open CWE link", ex);
                     }
                 }
+                @Override
+                public void mouseEntered(MouseEvent e) {
+                    cweLinkLabel.setForeground(JBColor.ORANGE); // Hover color
+                }
+                @Override
+                public void mouseExited(MouseEvent e) {
+                    cweLinkLabel.setForeground(JBColor.BLUE); // Default color
+                }
             });
             panel.add(cweLinkLabel, "wrap, gapbottom 3, gapleft 0");
-        } else {
-
         }
     }
 

--- a/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
@@ -4,10 +4,7 @@ import com.checkmarx.ast.codebashing.CodeBashing;
 import com.checkmarx.ast.learnMore.LearnMore;
 import com.checkmarx.ast.learnMore.Sample;
 import com.checkmarx.ast.predicate.Predicate;
-import com.checkmarx.ast.results.result.DependencyPath;
-import com.checkmarx.ast.results.result.Node;
-import com.checkmarx.ast.results.result.PackageData;
-import com.checkmarx.ast.results.result.Result;
+import com.checkmarx.ast.results.result.*;
 import com.checkmarx.ast.scan.Scan;
 import com.checkmarx.ast.wrapper.CxConstants;
 import com.checkmarx.ast.wrapper.CxException;
@@ -1052,9 +1049,9 @@ public class ResultNode extends DefaultMutableTreeNode {
         JBLabel cweLinkTitle = new JBLabel(String.format(Constants.HTML_BOLD_FORMAT, boldLabel("CWE Link").getText()));
         panel.add(cweLinkTitle, "span, growx");
 
-        String linkdetails = "https://cwe.mitre.org/data/definitions/" + result.getVulnerabilityDetails().getCweId() + ".html";
-
-        if (StringUtils.isNotBlank(linkdetails)) {
+        VulnerabilityDetails vulnerabilityDetails = result.getVulnerabilityDetails();
+        if (vulnerabilityDetails != null && StringUtils.isNotBlank(vulnerabilityDetails.getCweId())) {
+            String linkdetails = "https://cwe.mitre.org/data/definitions/" + vulnerabilityDetails.getCweId() + ".html";
             JBLabel cweLinkLabel = new JBLabel(String.format(Constants.HTML_WRAPPER_FORMAT, linkdetails.replaceAll("\n", "<br/>")));
             cweLinkLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
             cweLinkLabel.addMouseListener(new MouseAdapter() {
@@ -1068,6 +1065,8 @@ public class ResultNode extends DefaultMutableTreeNode {
                 }
             });
             panel.add(cweLinkLabel, "wrap, gapbottom 3, gapleft 0");
+        } else {
+
         }
     }
 

--- a/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
@@ -15,7 +15,6 @@ import com.checkmarx.intellij.service.StateService;
 import com.checkmarx.intellij.settings.global.CxWrapperFactory;
 import com.checkmarx.intellij.tool.window.FileNode;
 import com.checkmarx.intellij.tool.window.Severity;
-import org.apache.commons.text.StringEscapeUtils;
 import com.intellij.icons.AllIcons;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.application.ApplicationManager;

--- a/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
+++ b/src/main/java/com/checkmarx/intellij/tool/window/results/tree/nodes/ResultNode.java
@@ -1048,6 +1048,27 @@ public class ResultNode extends DefaultMutableTreeNode {
             panel.add(new JBLabel(String.format(Constants.HTML_WRAPPER_FORMAT, recommendations.replaceAll("\n", "<br/>"))),
                     "wrap, gapbottom 3, gapleft 0");
         }
+
+        JBLabel cweLinkTitle = new JBLabel(String.format(Constants.HTML_BOLD_FORMAT, boldLabel("CWE Link").getText()));
+        panel.add(cweLinkTitle, "span, growx");
+
+        String linkdetails = "https://cwe.mitre.org/data/definitions/" + result.getVulnerabilityDetails().getCweId() + ".html";
+
+        if (StringUtils.isNotBlank(linkdetails)) {
+            JBLabel cweLinkLabel = new JBLabel(String.format(Constants.HTML_WRAPPER_FORMAT, linkdetails.replaceAll("\n", "<br/>")));
+            cweLinkLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+            cweLinkLabel.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    try {
+                        Desktop.getDesktop().browse(new URI(linkdetails));
+                    } catch (IOException | URISyntaxException ex) {
+                        LOGGER.error("Failed to open CWE link", ex);
+                    }
+                }
+            });
+            panel.add(cweLinkLabel, "wrap, gapbottom 3, gapleft 0");
+        }
     }
 
     public void generateCodeSamples(@NotNull LearnMore learnMore, JPanel panel) {

--- a/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
+++ b/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
@@ -125,7 +125,9 @@ class ResultNodeTest {
             // Setup
             when(mockLearnMore.getRisk()).thenReturn(TEST_RISK);
             when(mockLearnMore.getCause()).thenReturn(TEST_CAUSE);
-            when(mockLearnMore.getGeneralRecommendations()).thenReturn("Genral Recommendation 1\nGeneral Recommendation 2");
+            when(mockLearnMore.getGeneralRecommendations()).thenReturn("General Recommendation 1\nGeneral Recommendation 2");
+            when(mockResult.getVulnerabilityDetails()).thenReturn(mockVulnDetails);
+            when(mockVulnDetails.getCweId()).thenReturn("79");
             mockedBundle.when(() -> Bundle.message(Resource.RISK)).thenReturn("Risk");
             mockedBundle.when(() -> Bundle.message(Resource.CAUSE)).thenReturn("Cause");
             mockedBundle.when(() -> Bundle.message(Resource.GENERAL_RECOMMENDATIONS)).thenReturn("Recommendations");
@@ -137,12 +139,15 @@ class ResultNodeTest {
             resultNode.generateLearnMore(mockLearnMore, panel);
 
             // Verify
-            assertEquals(6, panel.getComponentCount()); // Risk title, risk content, cause title, cause content, recommendations title
-            assertTrue(panel.getComponent(0) instanceof JLabel);
-            assertTrue(panel.getComponent(1) instanceof JBLabel);
-            assertTrue(panel.getComponent(2) instanceof JLabel);
-            assertTrue(panel.getComponent(3) instanceof JBLabel);
-            assertTrue(panel.getComponent(4) instanceof JLabel);
+            assertEquals(8, panel.getComponentCount()); // Adjusted to 8
+            assertTrue(panel.getComponent(0) instanceof JLabel); // Risk title
+            assertTrue(panel.getComponent(1) instanceof JBLabel); // Risk content
+            assertTrue(panel.getComponent(2) instanceof JLabel); // Cause title
+            assertTrue(panel.getComponent(3) instanceof JBLabel); // Cause content
+            assertTrue(panel.getComponent(4) instanceof JLabel); // Recommendations title
+            assertTrue(panel.getComponent(5) instanceof JLabel); // CWE Link title
+            assertTrue(panel.getComponent(6) instanceof JBLabel); // CWE Link label
+            assertTrue(panel.getComponent(7) instanceof JBLabel); // Verify the new component
         }
     }
 
@@ -152,6 +157,8 @@ class ResultNodeTest {
             // Setup
             when(mockLearnMore.getRisk()).thenReturn("");
             when(mockLearnMore.getCause()).thenReturn("");
+            when(mockResult.getVulnerabilityDetails()).thenReturn(mockVulnDetails);
+            when(mockVulnDetails.getCweId()).thenReturn("79");
             mockedBundle.when(() -> Bundle.message(Resource.RISK)).thenReturn("Risk");
             mockedBundle.when(() -> Bundle.message(Resource.CAUSE)).thenReturn("Cause");
             mockedBundle.when(() -> Bundle.message(Resource.GENERAL_RECOMMENDATIONS)).thenReturn("Recommendations");
@@ -163,10 +170,14 @@ class ResultNodeTest {
             resultNode.generateLearnMore(mockLearnMore, panel);
 
             // Verify
-            assertEquals(3, panel.getComponentCount()); // Only titles, no content
+            assertEquals(5, panel.getComponentCount()); // Titles and CWE link
             assertTrue(panel.getComponent(0) instanceof JLabel); // Risk title
             assertTrue(panel.getComponent(1) instanceof JLabel); // Cause title
             assertTrue(panel.getComponent(2) instanceof JLabel); // Recommendations title
+            assertTrue(panel.getComponent(3) instanceof JLabel); // CWE Link title
+            assertTrue(panel.getComponent(4) instanceof JBLabel); // CWE Link label
+            JBLabel cweLinkLabel = (JBLabel) panel.getComponent(4);
+            assertEquals("<html>https://cwe.mitre.org/data/definitions/79.html</html>", cweLinkLabel.getText());
         }
     }
 
@@ -188,7 +199,7 @@ class ResultNodeTest {
             resultNode.generateLearnMore(mockLearnMore, panel);
 
             // Verify
-            assertEquals(6, panel.getComponentCount());
+            assertEquals(7, panel.getComponentCount());
             JBLabel riskContent = (JBLabel) panel.getComponent(1);
             JBLabel causeContent = (JBLabel) panel.getComponent(3);
             assertEquals(riskContent.getText(), ("<html>Line 1<br/>Line 2</html>"));
@@ -475,32 +486,5 @@ class ResultNodeTest {
         assertTrue(titleLabel.getText().contains("test-package:1.0.0"));
         assertEquals(Severity.HIGH.getIcon(), titleLabel.getIcon());
     }
-
-    @Test
-    void generateLearnMore_WithCweLink_PrintsCweLinkToConsole() {
-        try (MockedStatic<Bundle> mockedBundle = mockStatic(Bundle.class)) {
-            // Setup
-            when(mockLearnMore.getRisk()).thenReturn(TEST_RISK);
-            when(mockLearnMore.getCause()).thenReturn(TEST_CAUSE);
-            when(mockLearnMore.getGeneralRecommendations()).thenReturn("General Recommendation");
-            when(mockResult.getVulnerabilityDetails()).thenReturn(mockVulnDetails);
-            when(mockVulnDetails.getCweId()).thenReturn(TEST_CWE);
-
-            mockedBundle.when(() -> Bundle.message(Resource.RISK)).thenReturn("Risk");
-            mockedBundle.when(() -> Bundle.message(Resource.CAUSE)).thenReturn("Cause");
-            mockedBundle.when(() -> Bundle.message(Resource.GENERAL_RECOMMENDATIONS)).thenReturn("Recommendations");
-
-            resultNode = new ResultNode(mockResult, mockProject, SCAN_ID);
-            JPanel panel = new JPanel();
-
-            // Execute
-            resultNode.generateLearnMore(mockLearnMore, panel);
-
-            // Verify
-            JBLabel cweLinkLabel = (JBLabel) panel.getComponent(6);
-            System.out.println("CWE Link: " + cweLinkLabel.getText());
-        }
-    }
-
 
 }

--- a/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
+++ b/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
@@ -476,5 +476,31 @@ class ResultNodeTest {
         assertEquals(Severity.HIGH.getIcon(), titleLabel.getIcon());
     }
 
+    @Test
+    void generateLearnMore_WithCweLink_PrintsCweLinkToConsole() {
+        try (MockedStatic<Bundle> mockedBundle = mockStatic(Bundle.class)) {
+            // Setup
+            when(mockLearnMore.getRisk()).thenReturn(TEST_RISK);
+            when(mockLearnMore.getCause()).thenReturn(TEST_CAUSE);
+            when(mockLearnMore.getGeneralRecommendations()).thenReturn("General Recommendation");
+            when(mockResult.getVulnerabilityDetails()).thenReturn(mockVulnDetails);
+            when(mockVulnDetails.getCweId()).thenReturn(TEST_CWE);
+
+            mockedBundle.when(() -> Bundle.message(Resource.RISK)).thenReturn("Risk");
+            mockedBundle.when(() -> Bundle.message(Resource.CAUSE)).thenReturn("Cause");
+            mockedBundle.when(() -> Bundle.message(Resource.GENERAL_RECOMMENDATIONS)).thenReturn("Recommendations");
+
+            resultNode = new ResultNode(mockResult, mockProject, SCAN_ID);
+            JPanel panel = new JPanel();
+
+            // Execute
+            resultNode.generateLearnMore(mockLearnMore, panel);
+
+            // Verify
+            JBLabel cweLinkLabel = (JBLabel) panel.getComponent(6);
+            System.out.println("CWE Link: " + cweLinkLabel.getText());
+        }
+    }
+
 
 }

--- a/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
+++ b/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
@@ -177,7 +177,7 @@ class ResultNodeTest {
             assertTrue(panel.getComponent(3) instanceof JLabel); // CWE Link title
             assertTrue(panel.getComponent(4) instanceof JBLabel); // CWE Link label
             JBLabel cweLinkLabel = (JBLabel) panel.getComponent(4);
-            assertEquals("<html>https://cwe.mitre.org/data/definitions/79.html</html>", cweLinkLabel.getText());
+            assertEquals("<html><a href='#'>CWE-79</a></html>", cweLinkLabel.getText());
         }
     }
 

--- a/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
+++ b/src/test/java/com/checkmarx/intellij/unit/tool/window/results/tree/nodes/ResultNodeTest.java
@@ -176,8 +176,9 @@ class ResultNodeTest {
             assertTrue(panel.getComponent(2) instanceof JLabel); // Recommendations title
             assertTrue(panel.getComponent(3) instanceof JLabel); // CWE Link title
             assertTrue(panel.getComponent(4) instanceof JBLabel); // CWE Link label
+
             JBLabel cweLinkLabel = (JBLabel) panel.getComponent(4);
-            assertEquals("<html><a href='#'>CWE-79</a></html>", cweLinkLabel.getText());
+            assertEquals("CWE-79", cweLinkLabel.getText());
         }
     }
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

This change updates the Learn More section to display the CWE reference as a clickable hyperlink _**([e.g., CWE-79](https://cwe.mitre.org/data/definitions/79.html))**_ instead of showing the full URL(https://cwe.mitre.org/data/definitions/79.html). The link appears blue, changes to orange on hover, and turns gray after being clicked, improving clarity and user experience. This update was made in reference to feedback from the demo, where the full link was previously shown.
### References

> [Added CWE link to Learn More section in IDE (AST-94778) #326
](https://github.com/Checkmarx/ast-jetbrains-plugin/pull/326)
### Testing
The change was tested manually in the IDE by verifying the following:

- The CWE link is displayed as a blue hyperlink (plain text, not full URL).
- On mouse hover, the link color changes to orange.
- After clicking the link, the color changes to gray to indicate it was visited.
- The link opens the correct CWE page in the default browser.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used

![image](https://github.com/user-attachments/assets/20abb393-a7e5-4f43-92c3-96481f40f9ff)
